### PR TITLE
Replace document.origin with window.origin

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -27,7 +27,7 @@ var createStartFn = function(tc, jasmineEnvPassedIn) {
     files = files.filter(function(file){
       return !(/lib\/adapter\.js/.test(file));
     }).map(function(file){
-      return document.origin + file;
+      return window.origin + file;
     });
 
     var blob = new Blob([SCRIPT], {type: 'application/javascript'});


### PR DESCRIPTION
This was removed from Chrome in October 2018 and now returns undefined.

The following error is printed from the web worker processing the `{"event":"start"}` message and trying to `importScripts()`.

```
01 03 2019 17:34:41.776:ERROR [Chrome 72.0.3626 (Mac OS X 10.14.2)]: Uncaught SyntaxError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The URL 'undefined/base/node_modules/karma-jasmine-web-worker/lib/jasmine.js' is invalid.
at blob:http://localhost:9876/bb8b7cd8-c228-4531-ba2e-89aa356fcb1c:6
```

